### PR TITLE
Add profile emoji overrides and transcript profile names (v0.4.8)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "campaign-mode",
   "description": "Quest-based extension for AI-assisted work. Three NPC agents (Gandalf, Dragon, Guardian) provide mentorship, adversarial testing, and quality gates for structured campaigns.",
-  "version": "0.4.6",
+  "version": "0.4.8",
   "author": {
     "name": "Chris Barlow"
   }

--- a/.claude/skills/dragon-agent/SKILL.md
+++ b/.claude/skills/dragon-agent/SKILL.md
@@ -18,7 +18,7 @@ The first line of every response must identify who is speaking:
 
 **`**🐉 Dragon:**`**
 
-Before responding, check if `.campaign/profiles/dragon.md` exists. If it does, read the profile and use the assigned `skin-name` instead of "Dragon" in the speaker tag and all self-references.
+Before responding, check if `.campaign/profiles/dragon.md` exists. If it does, read the profile and use the assigned `skin-name` instead of "Dragon" in the speaker tag and all self-references. If the profile has an `emoji` field, use that emoji instead of 🐉. Fall back to 🐉 when no profile or no `emoji` field is present.
 
 ## Campaign Conventions
 
@@ -188,7 +188,7 @@ At the end of every confrontation, record a full verbatim transcript of the conv
 **Write protocol:**
 1. Present your verdict, assessment, and transition options (including `AskUserQuestion`) first
 2. Then, in the same turn, execute tool calls: Bash `mkdir -p .campaign/conversations/` and Write to create the transcript file
-3. Construct the filename: `{YYYY-MM-DD}-{HH-MM}-dragon.md`
+3. Construct the filename: `{YYYY-MM-DD}-{HH-MM}-dragon.md` (or `{YYYY-MM-DD}-{HH-MM}-dragon({profile-name}).md` if a profile exists — lowercase, hyphens for spaces)
 4. Include YAML frontmatter (`agent: dragon`, profile name if applicable, phase, campaign mode, date) and the full verbatim exchange including the verdict
 5. Do not mention the transcript to the user — the tool calls happen silently after your response text
 

--- a/.claude/skills/gandalf-agent/SKILL.md
+++ b/.claude/skills/gandalf-agent/SKILL.md
@@ -18,7 +18,7 @@ The first line of every response must identify who is speaking:
 
 **`**🧙 Gandalf:**`**
 
-Before responding, check if `.campaign/profiles/gandalf.md` exists. If it does, read the profile and use the assigned `skin-name` instead of "Gandalf" in the speaker tag and all self-references. For example, if profiled as "The Sensei", use `**🧙 The Sensei:**`.
+Before responding, check if `.campaign/profiles/gandalf.md` exists. If it does, read the profile and use the assigned `skin-name` instead of "Gandalf" in the speaker tag and all self-references. If the profile has an `emoji` field, use that emoji instead of 🧙. For example, if profiled as "The Sensei" with emoji "🥋", use `**🥋 The Sensei:**`. Fall back to 🧙 when no profile or no `emoji` field is present.
 
 ## Campaign Conventions
 
@@ -364,7 +364,7 @@ At the end of every consultation, record a full verbatim transcript of the conve
 **Write protocol:**
 1. Present your response text (including any `AskUserQuestion` or transition options) first
 2. Then, in the same turn, execute tool calls: Bash `mkdir -p .campaign/conversations/` and Write to create the transcript file
-3. Construct the filename: `{YYYY-MM-DD}-{HH-MM}-gandalf.md`
+3. Construct the filename: `{YYYY-MM-DD}-{HH-MM}-gandalf.md` (or `{YYYY-MM-DD}-{HH-MM}-gandalf({profile-name}).md` if a profile exists — lowercase, hyphens for spaces)
 4. Include YAML frontmatter (`agent: gandalf`, profile name if applicable, phase, campaign mode, date) and the full verbatim exchange
 5. Do not mention the transcript to the user or break character — the tool calls happen silently after your response text
 

--- a/.claude/skills/guardian-agent/SKILL.md
+++ b/.claude/skills/guardian-agent/SKILL.md
@@ -18,7 +18,7 @@ The first line of every response must identify who is speaking:
 
 **`**🛡️ Guardian:**`**
 
-Before responding, check if `.campaign/profiles/guardian.md` exists. If it does, read the profile and use the assigned `skin-name` instead of "Guardian" in the speaker tag and all self-references.
+Before responding, check if `.campaign/profiles/guardian.md` exists. If it does, read the profile and use the assigned `skin-name` instead of "Guardian" in the speaker tag and all self-references. If the profile has an `emoji` field, use that emoji instead of 🛡️. Fall back to 🛡️ when no profile or no `emoji` field is present.
 
 ## Campaign Conventions
 
@@ -197,7 +197,7 @@ At the end of every checkpoint evaluation, record a full verbatim transcript of 
 **Write protocol:**
 1. Present your verdict, assessment, and transition options (including `AskUserQuestion`) first
 2. Then, in the same turn, execute tool calls: Bash `mkdir -p .campaign/conversations/` and Write to create the transcript file
-3. Construct the filename: `{YYYY-MM-DD}-{HH-MM}-guardian.md`
+3. Construct the filename: `{YYYY-MM-DD}-{HH-MM}-guardian.md` (or `{YYYY-MM-DD}-{HH-MM}-guardian({profile-name}).md` if a profile exists — lowercase, hyphens for spaces)
 4. Include YAML frontmatter (`agent: guardian`, profile name if applicable, phase, campaign mode, date) and the full verbatim exchange including the verdict
 5. Do not mention the transcript to the user — the tool calls happen silently after your response text
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,21 @@
 
 All notable changes to Campaign Mode are documented here.
 
-## v0.4.7 — Current Release
+## v0.4.8 — Current Release
+
+- **Profile emoji overrides** — Profiles can now include an optional `emoji` field in frontmatter. When present, speaker tags use the profile emoji instead of the archetype's hardcoded default. For example, Eeyore (Cat archetype in Hundred Acre Wood pack) now shows `**🫏 Eeyore:**` instead of `**🐱 Eeyore:**`. Fall back to archetype emoji when no profile or no emoji field exists.
+  - All 27 built-in profile pack files updated with character-appropriate emoji
+  - SPEC-CM-006-A v1.2: added `emoji` field to frontmatter table, updated examples, added emoji column to theme tables
+  - SPEC-CM-009-A: added `emoji` as optional frontmatter in Required Frontmatter section
+  - CLAUDE.md: speaker identification and profile name override paragraphs updated with emoji override logic
+  - council.md: Steps 1, 4, and 5 updated to read and use profile emoji
+  - All three NPC SKILL.md files: speaker identification sections updated with emoji override instructions
+  - animal-campaign-context.md: transcript format example updated to note profile emoji usage
+  - SPEC-CM-012-A v1.1: speaker tag examples updated to show profile emoji; filename convention updated to append profile name
+- **Transcript filename includes profile name** — When a profile exists, transcript filenames now append the profile's `skin-name` in round brackets: `{YYYY-MM-DD}-{HH-MM}-{agent}({profile-name}).md` (lowercase, hyphens for spaces). For example, `2026-02-18-14-32-cat(eeyore).md`. Makes it easy to identify which character was consulted when scanning conversation logs. No brackets when no profile is assigned.
+  - Updated: SPEC-CM-012-A, CLAUDE.md, animal-campaign-context.md, all NPC SKILL.md files, council.md, SPEC-CM-006-B, ADR-CM-019
+
+## v0.4.7
 
 - **Fix: Transcripts sometimes summarised instead of verbatim** — Instructions said "full verbatim" but never explicitly warned against summarising. LLMs naturally compress long content unless told not to, and the template placeholder `{...full exchange...}` was ambiguous. Added explicit anti-summarisation language ("Do not summarise, condense, paraphrase, or omit") to every transcript recording instruction: CLAUDE.md, animal-campaign-context.md, Gandalf SKILL.md, Guardian SKILL.md, Dragon SKILL.md. Expanded template examples to show multiple message turns instead of an ambiguous ellipsis. Updated SPEC-CM-012-A body sections table, write protocol, and template format to reinforce the requirement.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,9 +12,9 @@ When invoked as an NPC agent, adopt the full identity defined in that agent's SK
 - Do not break character to offer general Claude assistance while acting as an NPC
 - When not invoked as a specific NPC, operate normally as Claude
 
-**Speaker identification:** The first line of every agent response must identify who is speaking with emoji and bold name (e.g., `**🧙 Gandalf:**`, `**🐉 Dragon:**`, `**🛡️ Guardian:**`, `**🐻 Bear:**`, `**🐱 Cat:**`, `**🦉 Owl:**`, `**🐶 Puppy:**`, `**🐰 Rabbit:**`, `**🐺 Wolf:**`).
+**Speaker identification:** The first line of every agent response must identify who is speaking with emoji and bold name (e.g., `**🧙 Gandalf:**`, `**🐉 Dragon:**`, `**🛡️ Guardian:**`, `**🐻 Bear:**`, `**🐱 Cat:**`, `**🦉 Owl:**`, `**🐶 Puppy:**`, `**🐰 Rabbit:**`, `**🐺 Wolf:**`). If the agent has a profile in `.campaign/profiles/` with an `emoji` field, use the profile emoji instead of the archetype's default emoji. Fall back to the archetype emoji when no profile or no `emoji` field is present.
 
-**Profile name override:** If an agent has a profile in `.campaign/profiles/`, always use their assigned name — never their archetype name. This applies everywhere: speaker tags, self-references, other agents referring to them, `AskUserQuestion` options, and progress log entries. Before responding, agents must check `.campaign/profiles/` for their profile and use the assigned name if one exists.
+**Profile name and emoji override:** If an agent has a profile in `.campaign/profiles/`, always use their assigned name — never their archetype name. If the profile includes an `emoji` field, use that emoji in speaker tags instead of the archetype's default. This applies everywhere: speaker tags, self-references, other agents referring to them, `AskUserQuestion` options, and progress log entries. Before responding, agents must check `.campaign/profiles/` for their profile and use the assigned name and emoji if they exist.
 
 **Agent selection menus:** When presenting the user with a choice of which agent to consult (e.g., "Consult an animal advisor", "Which perspective do you want?"), check `.campaign/profiles/` first. Use profile names in place of archetype names in all option labels and descriptions. For example, if Bear is profiled as "Paladin" and Cat as "Rogue", present "Consult the Paladin (Bear — vision and direction)" rather than "Consult the Bear". Include the archetype in parentheses so the user knows the underlying role.
 
@@ -77,7 +77,7 @@ When `.campaign/quest.md` exists and the campaign is in Phase 3 (Campaign Execut
 
 When `.campaign/quest.md` exists and the campaign is active, **all agents** must record a full conversation transcript at the end of each consultation.
 
-**Where:** `.campaign/conversations/{YYYY-MM-DD}-{HH-MM}-{agent}.md` (date-first for chronological sort)
+**Where:** `.campaign/conversations/{YYYY-MM-DD}-{HH-MM}-{agent}.md` (date-first for chronological sort). If a profile exists, append the profile name in round brackets: `{YYYY-MM-DD}-{HH-MM}-{agent}({profile-name}).md` (lowercase, hyphens for spaces).
 
 **What to capture:**
 - YAML frontmatter: agent archetype, profile name (if applicable), phase, campaign mode, date

--- a/commands/council.md
+++ b/commands/council.md
@@ -15,7 +15,7 @@ Ensure the `.campaign/` directory exists. If it does not, create it:
 mkdir -p .campaign/
 ```
 
-Check `.campaign/profiles/` for profile name overrides — use Glob to look for profile files. If profiles exist, read them to get assigned names. Use profile names instead of archetype names throughout the Council session (in speaker tags, the report, and transition options). Include the archetype in parentheses for clarity where needed.
+Check `.campaign/profiles/` for profile name and emoji overrides — use Glob to look for profile files. If profiles exist, read them to get assigned names and emoji. Use profile names instead of archetype names throughout the Council session (in speaker tags, the report, and transition options). If a profile has an `emoji` field, use that emoji in speaker tags instead of the archetype's default. Include the archetype in parentheses for clarity where needed.
 
 Check if `.campaign/quest.md` exists. If it does, read it to understand any active quest context. The Council can operate with or without an active quest.
 
@@ -81,14 +81,14 @@ If an active quest exists (from Step 1), note it:
 
 For each animal in this order — **Bear, Cat, Owl, Puppy, Rabbit, Wolf** — deliver an in-character analysis:
 
-1. Check `.campaign/profiles/{animal}.md` for a profile name. Use the profile name in the speaker tag if one exists; otherwise use the archetype name.
+1. Check `.campaign/profiles/{animal}.md` for a profile name and emoji. Use the profile name in the speaker tag if one exists; otherwise use the archetype name. If the profile has an `emoji` field, use that emoji; otherwise use the archetype's default emoji.
 2. Use the correct speaker tag format: `**{emoji} {Name}:**`
-   - Bear: `**🐻 Bear:**` (or profile name)
-   - Cat: `**🐱 Cat:**` (or profile name)
-   - Owl: `**🦉 Owl:**` (or profile name)
-   - Puppy: `**🐶 Puppy:**` (or profile name)
-   - Rabbit: `**🐰 Rabbit:**` (or profile name)
-   - Wolf: `**🐺 Wolf:**` (or profile name)
+   - Bear: `**🐻 Bear:**` (or profile emoji + profile name)
+   - Cat: `**🐱 Cat:**` (or profile emoji + profile name)
+   - Owl: `**🦉 Owl:**` (or profile emoji + profile name)
+   - Puppy: `**🐶 Puppy:**` (or profile emoji + profile name)
+   - Rabbit: `**🐰 Rabbit:**` (or profile emoji + profile name)
+   - Wolf: `**🐺 Wolf:**` (or profile emoji + profile name)
 3. Explore the project using Glob and Read. Examine whatever content exists — code, documentation, configuration, data, tests, READMEs, structure. This is a project-wide diagnostic, not limited to code.
 4. Deliver **3–5 observations** through the archetype lens. Each animal focuses on their core concern:
 
@@ -109,7 +109,7 @@ Each animal should speak in character — brief, direct, through their archetype
 
 After all six animals have spoken:
 
-1. Check `.campaign/profiles/simon.md` for a profile name. Use the speaker tag format: `**🎓 Simon:**` (or profile name with appropriate emoji).
+1. Check `.campaign/profiles/simon.md` for a profile name and emoji. Use the speaker tag format: `**🎓 Simon:**` (or profile name with profile emoji if available, otherwise appropriate default emoji).
 2. Synthesise the six perspectives into a cohesive assessment:
    - **Common themes** — What did multiple animals agree on?
    - **Key tensions** — Where did perspectives conflict or highlight trade-offs?
@@ -172,7 +172,7 @@ If profiles exist, use profile names in the section headers (e.g., `### Paladin 
 After writing the council report, record a full verbatim transcript of the council session. Do this silently — do not mention it to the user.
 
 1. Use Bash to ensure the directory exists: `mkdir -p .campaign/conversations/`
-2. Construct the filename: `{YYYY-MM-DD}-{HH-MM}-council.md`
+2. Construct the filename: `{YYYY-MM-DD}-{HH-MM}-council.md` (council transcripts do not append a profile name)
 3. Use the Write tool to create the transcript file with the following format:
 
 ```yaml

--- a/docs/2_adrs/ADR-CM-019-Conversation-Transcript-Recording.md
+++ b/docs/2_adrs/ADR-CM-019-Conversation-Transcript-Recording.md
@@ -45,7 +45,7 @@ The solution is automatic transcript recording: every agent consultation produce
 
 ### Option 1: Per-Session Transcript Files (Selected)
 
-One file per conversation session in `.campaign/conversations/`, named with date-first format (`{YYYY-MM-DD}-{HH-MM}-{agent}.md`) for chronological sorting.
+One file per conversation session in `.campaign/conversations/`, named with date-first format (`{YYYY-MM-DD}-{HH-MM}-{agent}.md`, or `{YYYY-MM-DD}-{HH-MM}-{agent}({profile-name}).md` when a profile exists) for chronological sorting.
 
 **Pros:**
 - Each conversation is a discrete, findable file

--- a/docs/3_specs/SPEC-CM-006-A-Character-Profile-Format.md
+++ b/docs/3_specs/SPEC-CM-006-A-Character-Profile-Format.md
@@ -4,9 +4,9 @@
 |-------|-------|
 | **Specification ID** | SPEC-CM-006-A |
 | **Parent ADR** | [ADR-CM-006](../2_adrs/ADR-CM-006-Character-Generation.md) |
-| **Version** | 1.1 |
+| **Version** | 1.2 |
 | **Status** | Draft |
-| **Last Updated** | 2026-02-16 |
+| **Last Updated** | 2026-02-23 |
 
 ---
 
@@ -47,6 +47,7 @@ Profile files are stored at `.campaign/profiles/{archetype}.md` where `{archetyp
 archetype: bear
 skin-name: "The Paladin"
 theme: "Fantasy"
+emoji: "⚔️"
 ---
 ```
 
@@ -55,6 +56,7 @@ theme: "Fantasy"
 | `archetype` | Yes | bear, cat, owl, puppy, rabbit, wolf, gandalf, dragon, guardian | Which agent this profile applies to |
 | `skin-name` | Yes | Free text | Display name for this characterisation |
 | `theme` | Yes | Free text | Theme this profile belongs to (e.g., "Fantasy", "Hundred Acre Wood", "Neutral") |
+| `emoji` | No | Single emoji | Emoji for speaker tags. Overrides the archetype's default emoji when present. |
 
 ### Body Sections
 
@@ -170,62 +172,62 @@ Themes are optional overlays that provide vocabulary, metaphors, and suggested p
 
 Professional, accessible language. Suitable for any context.
 
-| Archetype | Suggested Skin Name |
-|-----------|---------------------|
-| Bear | Visionary Leader |
-| Cat | Risk Analyst |
-| Owl | Timekeeper |
-| Puppy | Morale Officer |
-| Rabbit | Resource Coordinator |
-| Wolf | Team Captain |
+| Archetype | Suggested Skin Name | Emoji |
+|-----------|---------------------|-------|
+| Bear | Visionary Leader | |
+| Cat | Risk Analyst | |
+| Owl | Timekeeper | |
+| Puppy | Morale Officer | |
+| Rabbit | Resource Coordinator | |
+| Wolf | Team Captain | |
 
 #### Fantasy
 
 D&D-inspired characterisations. Available as a profile pack in `profile-packs/fantasy/`.
 
-| Archetype | Suggested Skin Name |
-|-----------|---------------------|
-| Bear | The Paladin |
-| Cat | The Rogue |
-| Owl | The Sage |
-| Puppy | The Bard |
-| Rabbit | The Artificer |
-| Wolf | The Warden |
-| Gandalf | The Archmage |
-| Dragon | The Ancient Wyrm |
-| Guardian | The Sentinel |
+| Archetype | Suggested Skin Name | Emoji |
+|-----------|---------------------|-------|
+| Bear | The Paladin | ⚔️ |
+| Cat | The Rogue | 🗡️ |
+| Owl | The Sage | 📜 |
+| Puppy | The Bard | 🎵 |
+| Rabbit | The Artificer | ⚒️ |
+| Wolf | The Warden | 🏹 |
+| Gandalf | The Archmage | 🧙 |
+| Dragon | The Ancient Wyrm | 🐉 |
+| Guardian | The Sentinel | 🛡️ |
 
 #### Hundred Acre Wood
 
 Winnie-the-Pooh inspired characterisations. Available as a profile pack in `profile-packs/hundred-acre-wood/`.
 
-| Archetype | Suggested Skin Name |
-|-----------|---------------------|
-| Bear | Pooh |
-| Cat | Eeyore |
-| Owl | Owl |
-| Puppy | Tigger |
-| Rabbit | Rabbit |
-| Wolf | Piglet |
-| Gandalf | Christopher Robin |
-| Dragon | Heffalump |
-| Guardian | Kanga |
+| Archetype | Suggested Skin Name | Emoji |
+|-----------|---------------------|-------|
+| Bear | Pooh | 🍯 |
+| Cat | Eeyore | 🫏 |
+| Owl | Owl | 🦉 |
+| Puppy | Tigger | 🐯 |
+| Rabbit | Rabbit | 🐰 |
+| Wolf | Piglet | 🐷 |
+| Gandalf | Christopher Robin | 👦 |
+| Dragon | Heffalump | 🐘 |
+| Guardian | Kanga | 🦘 |
 
 #### Family & Parenting
 
 Family-role characterisations grounded in real-world parenting dynamics. Available as a profile pack in `profile-packs/family-parenting/`.
 
-| Archetype | Suggested Skin Name |
-|-----------|---------------------|
-| Bear | The Elder |
-| Cat | The Teenager |
-| Owl | The Family Therapist |
-| Puppy | The Neighbour Kid |
-| Rabbit | The Co-Parent |
-| Wolf | The Older Sibling |
-| Gandalf | The Paediatrician |
-| Dragon | Great Aunt Betty |
-| Guardian | The Social Worker |
+| Archetype | Suggested Skin Name | Emoji |
+|-----------|---------------------|-------|
+| Bear | The Elder | 👴 |
+| Cat | The Teenager | 📱 |
+| Owl | The Family Therapist | 🛋️ |
+| Puppy | The Neighbour Kid | 🧒 |
+| Rabbit | The Co-Parent | 🤝 |
+| Wolf | The Older Sibling | 🫂 |
+| Gandalf | The Paediatrician | 🩺 |
+| Dragon | Great Aunt Betty | 👵 |
+| Guardian | The Social Worker | 📋 |
 
 ### Custom Themes
 
@@ -249,6 +251,7 @@ Users can create custom themes via Socratic dialogue with Gandalf. Any framing t
 archetype: bear
 skin-name: "The Paladin"
 theme: "Fantasy"
+emoji: "⚔️"
 ---
 
 # Bear — The Paladin
@@ -273,6 +276,7 @@ A steadfast holy warrior who sees the quest as a sacred charge. The Paladin fram
 archetype: cat
 skin-name: "The Rogue"
 theme: "Fantasy"
+emoji: "🗡️"
 ---
 
 # Cat — The Rogue
@@ -303,6 +307,7 @@ A cunning, streetwise rogue who sees every situation as a puzzle to be picked ap
 archetype: gandalf
 skin-name: "The Archmage"
 theme: "Fantasy"
+emoji: "🧙"
 ---
 
 # Gandalf — The Archmage
@@ -353,3 +358,4 @@ New profiles should use v1.1 format exclusively.
 |---------|------|--------|---------|
 | 1.0 | 2026-02-14 | Chris Barlow | Initial specification |
 | 1.1 | 2026-02-16 | Chris Barlow | Unified frontmatter (`archetype`/`skin-name`/`theme`) for all agent types. Dropped explicit `depth` field (inferred from content). Relaxed body section naming. Added NPC profiles to examples. Added migration guide from v1.0. Added Hundred Acre Wood theme. Added profile pack cross-references. |
+| 1.2 | 2026-02-23 | Chris Barlow | Added optional `emoji` field to frontmatter for profile-specific emoji overrides. Added emoji column to all theme tables. Updated profile examples with emoji. |

--- a/docs/3_specs/SPEC-CM-006-B-Campaign-State-Directory.md
+++ b/docs/3_specs/SPEC-CM-006-B-Campaign-State-Directory.md
@@ -222,7 +222,7 @@ When character profiles exist in `.campaign/profiles/`, section headers use the 
 
 The conversations directory stores full verbatim transcripts of every agent consultation during a campaign. Each file captures one conversation session — the complete exchange between the user and a single agent (or the Council as a whole).
 
-Files are named with a date-first format (`{YYYY-MM-DD}-{HH-MM}-{agent}.md`) for chronological sorting. The agent identifier uses the archetype name (lowercase), not the profile name — the profile name appears in frontmatter instead.
+Files are named with a date-first format (`{YYYY-MM-DD}-{HH-MM}-{agent}.md`) for chronological sorting. The agent identifier uses the archetype name (lowercase). When a profile exists, the profile's `skin-name` is appended in round brackets (lowercase, hyphens for spaces) — e.g., `2026-02-18-14-32-cat(eeyore).md`. The profile name also appears in frontmatter.
 
 Transcript format, write protocol, isolation rules, and timing are defined in [SPEC-CM-012-A](SPEC-CM-012-A-Conversation-Transcript-Protocol.md).
 

--- a/docs/3_specs/SPEC-CM-009-A-Profile-Pack-Format.md
+++ b/docs/3_specs/SPEC-CM-009-A-Profile-Pack-Format.md
@@ -4,9 +4,9 @@
 |-------|-------|
 | **Specification ID** | SPEC-CM-009-A |
 | **Parent ADR** | [ADR-CM-016](../2_adrs/ADR-CM-016-Profile-Packs.md) |
-| **Version** | 1.0 |
+| **Version** | 1.1 |
 | **Status** | Draft |
-| **Last Updated** | 2026-02-16 |
+| **Last Updated** | 2026-02-23 |
 
 ---
 
@@ -52,12 +52,14 @@ Each profile file in a pack must follow [SPEC-CM-006-A v1.1](SPEC-CM-006-A-Chara
 archetype: bear
 skin-name: "The Paladin"
 theme: "Fantasy"
+emoji: "⚔️"
 ---
 ```
 
 - `archetype` must match the file name (without `.md`)
 - `skin-name` is the display name for this characterisation
 - `theme` must match the pack's theme name (title case or natural form)
+- `emoji` (optional) overrides the archetype's default emoji in speaker tags. When present, agents use this emoji instead of the hardcoded archetype emoji.
 
 ### Required Body Sections
 
@@ -166,3 +168,4 @@ Community members can submit new profile packs via pull request. See [CONTRIBUTI
 | Version | Date | Author | Changes |
 |---------|------|--------|---------|
 | 1.0 | 2026-02-16 | Chris Barlow | Initial specification |
+| 1.1 | 2026-02-23 | Chris Barlow | Added optional `emoji` field to Required Frontmatter section for profile-specific emoji overrides. |

--- a/docs/3_specs/SPEC-CM-012-A-Conversation-Transcript-Protocol.md
+++ b/docs/3_specs/SPEC-CM-012-A-Conversation-Transcript-Protocol.md
@@ -4,9 +4,9 @@
 |-------|-------|
 | **Specification ID** | SPEC-CM-012-A |
 | **Parent ADR** | [ADR-CM-019](../2_adrs/ADR-CM-019-Conversation-Transcript-Recording.md) |
-| **Version** | 1.0 |
+| **Version** | 1.1 |
 | **Status** | Draft |
-| **Last Updated** | 2026-02-18 |
+| **Last Updated** | 2026-02-23 |
 
 ---
 
@@ -30,11 +30,13 @@ Created on first use via `mkdir -p .campaign/conversations/`.
 
 ```
 {YYYY-MM-DD}-{HH-MM}-{agent}.md
+{YYYY-MM-DD}-{HH-MM}-{agent}({profile-name}).md
 ```
 
 - Date-first ensures chronological sort order when listing files by name
 - Time uses 24-hour format
 - Agent is the archetype name (lowercase), not the profile name
+- If a profile exists, append the profile's `skin-name` in round brackets — lowercase, spaces replaced with hyphens. Omit the brackets entirely when no profile is assigned.
 
 ### Agent Values
 
@@ -56,10 +58,12 @@ Valid agent identifiers for filenames:
 ### Example Filenames
 
 ```
-2026-02-18-14-32-cat.md
-2026-02-18-15-10-owl.md
-2026-02-18-16-00-guardian.md
-2026-02-19-09-15-gandalf.md
+2026-02-18-14-32-cat.md                         (no profile)
+2026-02-18-14-32-cat(eeyore).md                  (Hundred Acre Wood profile)
+2026-02-18-15-10-owl(the-sage).md                (Fantasy profile)
+2026-02-18-16-00-guardian(kanga).md               (Hundred Acre Wood profile)
+2026-02-19-09-15-gandalf.md                      (no profile)
+2026-02-19-09-15-gandalf(christopher-robin).md   (Hundred Acre Wood profile)
 ```
 
 ---
@@ -116,9 +120,9 @@ Consultation purpose: {e.g., Phase 3 advisory, Guardian checkpoint, Dragon confr
 
 ### Speaker Tags in Exchange
 
-Use the same speaker identification format as the agent's normal responses:
-- Animals: `**{emoji} {Name}:**` (e.g., `**🐱 Rogue:**` or `**🐱 Cat:**`)
-- NPCs: `**{emoji} {Name}:**` (e.g., `**🧙 Gandalf:**`, `**🛡️ Guardian:**`, `**🐉 Dragon:**`)
+Use the same speaker identification format as the agent's normal responses. If the agent's profile has an `emoji` field, use the profile emoji instead of the archetype default:
+- Animals: `**{emoji} {Name}:**` (e.g., `**🗡️ Rogue:**` with profile emoji, or `**🐱 Cat:**` with archetype default)
+- NPCs: `**{emoji} {Name}:**` (e.g., `**🧙 The Archmage:**`, `**🦘 Kanga:**` with profile emoji, or `**🛡️ Guardian:**` with archetype default)
 - User: `**User:**`
 - Council animals: Each animal uses its own speaker tag within the council transcript
 
@@ -129,7 +133,7 @@ Use the same speaker identification format as the agent's normal responses:
 Every agent follows this protocol at the end of each consultation:
 
 1. **Ensure directory exists:** Use Bash to run `mkdir -p .campaign/conversations/`
-2. **Construct filename:** Use the agent's archetype name and the current date/time in the format `{YYYY-MM-DD}-{HH-MM}-{agent}.md`
+2. **Construct filename:** Use the agent's archetype name and the current date/time in the format `{YYYY-MM-DD}-{HH-MM}-{agent}.md`. If a profile exists, append the profile's `skin-name` in round brackets (lowercase, hyphens for spaces): `{YYYY-MM-DD}-{HH-MM}-{agent}({profile-name}).md`
 3. **Construct transcript:** Build the full transcript from the conversation, including frontmatter, context, verbatim exchange, and outcome (if applicable). **Verbatim means verbatim** — every message from both user and agent must appear exactly as it occurred. Do not summarise, condense, paraphrase, or omit any part of the exchange. If the conversation was long, the transcript is long.
 4. **Write file:** Use the Write tool to create the file in `.campaign/conversations/`
 5. **Do silently:** Do not mention the transcript to the user. Do not break character to perform this step. This is a background housekeeping task.
@@ -185,3 +189,4 @@ Context isolation (ADR-CM-003, SPEC-CM-003-A) applies to transcript files. Trans
 | Version | Date | Author | Changes |
 |---------|------|--------|---------|
 | 1.0 | 2026-02-18 | Chris Barlow | Initial specification |
+| 1.1 | 2026-02-23 | Chris Barlow | Speaker tags use profile emoji when available. Filename convention appends profile name in round brackets when a profile exists. |

--- a/extensions/animal-campaign-context.md
+++ b/extensions/animal-campaign-context.md
@@ -37,7 +37,7 @@ At the end of every consultation, record a full verbatim transcript of the conve
 
 **Write protocol:**
 1. Use Bash to ensure the directory exists: `mkdir -p .campaign/conversations/`
-2. Construct the filename: `{YYYY-MM-DD}-{HH-MM}-{agent}.md` where `{agent}` is your archetype name in lowercase (e.g., `bear`, `cat`, `owl`, `puppy`, `rabbit`, `wolf`)
+2. Construct the filename: `{YYYY-MM-DD}-{HH-MM}-{agent}.md` where `{agent}` is your archetype name in lowercase (e.g., `bear`, `cat`, `owl`, `puppy`, `rabbit`, `wolf`). If you have a profile, append the profile's `skin-name` in round brackets (lowercase, hyphens for spaces) — e.g., `2026-02-18-14-32-cat(eeyore).md`
 3. Use the Write tool to create the transcript file
 4. Do this as tool calls at the end of your response, after presenting Next Perspective options — the transcript is written in the same turn before the user responds
 
@@ -61,7 +61,7 @@ Consultation purpose: Phase 3 advisory
 ### Exchange
 **User:** {verbatim user message}
 
-**{emoji} {Name}:** {verbatim agent response}
+**{emoji} {Name}:** {verbatim agent response — use profile emoji from `emoji` field if present, otherwise archetype default}
 
 **User:** {verbatim user message}
 

--- a/profile-packs/family-parenting/bear.md
+++ b/profile-packs/family-parenting/bear.md
@@ -2,6 +2,7 @@
 archetype: bear
 skin-name: "The Elder"
 theme: "Family & Parenting"
+emoji: "👴"
 ---
 
 # Bear — The Elder

--- a/profile-packs/family-parenting/cat.md
+++ b/profile-packs/family-parenting/cat.md
@@ -2,6 +2,7 @@
 archetype: cat
 skin-name: "The Teenager"
 theme: "Family & Parenting"
+emoji: "📱"
 ---
 
 # Cat — The Teenager

--- a/profile-packs/family-parenting/dragon.md
+++ b/profile-packs/family-parenting/dragon.md
@@ -2,6 +2,7 @@
 archetype: dragon
 skin-name: "Great Aunt Betty"
 theme: "Family & Parenting"
+emoji: "👵"
 ---
 
 # Dragon — Great Aunt Betty

--- a/profile-packs/family-parenting/gandalf.md
+++ b/profile-packs/family-parenting/gandalf.md
@@ -2,6 +2,7 @@
 archetype: gandalf
 skin-name: "The Paediatrician"
 theme: "Family & Parenting"
+emoji: "🩺"
 ---
 
 # Gandalf — The Paediatrician

--- a/profile-packs/family-parenting/guardian.md
+++ b/profile-packs/family-parenting/guardian.md
@@ -2,6 +2,7 @@
 archetype: guardian
 skin-name: "The Social Worker"
 theme: "Family & Parenting"
+emoji: "📋"
 ---
 
 # Guardian — The Social Worker

--- a/profile-packs/family-parenting/owl.md
+++ b/profile-packs/family-parenting/owl.md
@@ -2,6 +2,7 @@
 archetype: owl
 skin-name: "The Family Therapist"
 theme: "Family & Parenting"
+emoji: "🛋️"
 ---
 
 # Owl — The Family Therapist

--- a/profile-packs/family-parenting/puppy.md
+++ b/profile-packs/family-parenting/puppy.md
@@ -2,6 +2,7 @@
 archetype: puppy
 skin-name: "The Neighbour Kid"
 theme: "Family & Parenting"
+emoji: "🧒"
 ---
 
 # Puppy — The Neighbour Kid

--- a/profile-packs/family-parenting/rabbit.md
+++ b/profile-packs/family-parenting/rabbit.md
@@ -2,6 +2,7 @@
 archetype: rabbit
 skin-name: "The Co-Parent"
 theme: "Family & Parenting"
+emoji: "🤝"
 ---
 
 # Rabbit — The Co-Parent

--- a/profile-packs/family-parenting/wolf.md
+++ b/profile-packs/family-parenting/wolf.md
@@ -2,6 +2,7 @@
 archetype: wolf
 skin-name: "The Older Sibling"
 theme: "Family & Parenting"
+emoji: "🫂"
 ---
 
 # Wolf — The Older Sibling

--- a/profile-packs/fantasy/bear.md
+++ b/profile-packs/fantasy/bear.md
@@ -2,6 +2,7 @@
 archetype: bear
 skin-name: "The Paladin"
 theme: "Fantasy"
+emoji: "⚔️"
 ---
 
 # Bear — The Paladin

--- a/profile-packs/fantasy/cat.md
+++ b/profile-packs/fantasy/cat.md
@@ -2,6 +2,7 @@
 archetype: cat
 skin-name: "The Rogue"
 theme: "Fantasy"
+emoji: "🗡️"
 ---
 
 # Cat — The Rogue

--- a/profile-packs/fantasy/dragon.md
+++ b/profile-packs/fantasy/dragon.md
@@ -2,6 +2,7 @@
 archetype: dragon
 skin-name: "The Ancient Wyrm"
 theme: "Fantasy"
+emoji: "🐉"
 ---
 
 # Dragon — The Ancient Wyrm

--- a/profile-packs/fantasy/gandalf.md
+++ b/profile-packs/fantasy/gandalf.md
@@ -2,6 +2,7 @@
 archetype: gandalf
 skin-name: "The Archmage"
 theme: "Fantasy"
+emoji: "🧙"
 ---
 
 # Gandalf — The Archmage

--- a/profile-packs/fantasy/guardian.md
+++ b/profile-packs/fantasy/guardian.md
@@ -2,6 +2,7 @@
 archetype: guardian
 skin-name: "The Sentinel"
 theme: "Fantasy"
+emoji: "🛡️"
 ---
 
 # Guardian — The Sentinel

--- a/profile-packs/fantasy/owl.md
+++ b/profile-packs/fantasy/owl.md
@@ -2,6 +2,7 @@
 archetype: owl
 skin-name: "The Sage"
 theme: "Fantasy"
+emoji: "📜"
 ---
 
 # Owl — The Sage

--- a/profile-packs/fantasy/puppy.md
+++ b/profile-packs/fantasy/puppy.md
@@ -2,6 +2,7 @@
 archetype: puppy
 skin-name: "The Bard"
 theme: "Fantasy"
+emoji: "🎵"
 ---
 
 # Puppy — The Bard

--- a/profile-packs/fantasy/rabbit.md
+++ b/profile-packs/fantasy/rabbit.md
@@ -2,6 +2,7 @@
 archetype: rabbit
 skin-name: "The Artificer"
 theme: "Fantasy"
+emoji: "⚒️"
 ---
 
 # Rabbit — The Artificer

--- a/profile-packs/fantasy/wolf.md
+++ b/profile-packs/fantasy/wolf.md
@@ -2,6 +2,7 @@
 archetype: wolf
 skin-name: "The Warden"
 theme: "Fantasy"
+emoji: "🏹"
 ---
 
 # Wolf — The Warden

--- a/profile-packs/hundred-acre-wood/bear.md
+++ b/profile-packs/hundred-acre-wood/bear.md
@@ -2,6 +2,7 @@
 archetype: bear
 skin-name: "Pooh"
 theme: "Hundred Acre Wood"
+emoji: "🍯"
 ---
 
 # Bear — Pooh

--- a/profile-packs/hundred-acre-wood/cat.md
+++ b/profile-packs/hundred-acre-wood/cat.md
@@ -2,6 +2,7 @@
 archetype: cat
 skin-name: "Eeyore"
 theme: "Hundred Acre Wood"
+emoji: "🫏"
 ---
 
 # Cat — Eeyore

--- a/profile-packs/hundred-acre-wood/dragon.md
+++ b/profile-packs/hundred-acre-wood/dragon.md
@@ -2,6 +2,7 @@
 archetype: dragon
 skin-name: "Heffalump"
 theme: "Hundred Acre Wood"
+emoji: "🐘"
 ---
 
 # Dragon — Heffalump

--- a/profile-packs/hundred-acre-wood/gandalf.md
+++ b/profile-packs/hundred-acre-wood/gandalf.md
@@ -2,6 +2,7 @@
 archetype: gandalf
 skin-name: "Christopher Robin"
 theme: "Hundred Acre Wood"
+emoji: "👦"
 ---
 
 # Gandalf — Christopher Robin

--- a/profile-packs/hundred-acre-wood/guardian.md
+++ b/profile-packs/hundred-acre-wood/guardian.md
@@ -2,6 +2,7 @@
 archetype: guardian
 skin-name: "Kanga"
 theme: "Hundred Acre Wood"
+emoji: "🦘"
 ---
 
 # Guardian — Kanga

--- a/profile-packs/hundred-acre-wood/owl.md
+++ b/profile-packs/hundred-acre-wood/owl.md
@@ -2,6 +2,7 @@
 archetype: owl
 skin-name: "Owl"
 theme: "Hundred Acre Wood"
+emoji: "🦉"
 ---
 
 # Owl — Owl

--- a/profile-packs/hundred-acre-wood/puppy.md
+++ b/profile-packs/hundred-acre-wood/puppy.md
@@ -2,6 +2,7 @@
 archetype: puppy
 skin-name: "Tigger"
 theme: "Hundred Acre Wood"
+emoji: "🐯"
 ---
 
 # Puppy — Tigger

--- a/profile-packs/hundred-acre-wood/rabbit.md
+++ b/profile-packs/hundred-acre-wood/rabbit.md
@@ -2,6 +2,7 @@
 archetype: rabbit
 skin-name: "Rabbit"
 theme: "Hundred Acre Wood"
+emoji: "🐰"
 ---
 
 # Rabbit — Rabbit

--- a/profile-packs/hundred-acre-wood/wolf.md
+++ b/profile-packs/hundred-acre-wood/wolf.md
@@ -2,6 +2,7 @@
 archetype: wolf
 skin-name: "Piglet"
 theme: "Hundred Acre Wood"
+emoji: "🐷"
 ---
 
 # Wolf — Piglet

--- a/skills/dragon-agent/SKILL.md
+++ b/skills/dragon-agent/SKILL.md
@@ -18,7 +18,7 @@ The first line of every response must identify who is speaking:
 
 **`**🐉 Dragon:**`**
 
-Before responding, check if `.campaign/profiles/dragon.md` exists. If it does, read the profile and use the assigned `skin-name` instead of "Dragon" in the speaker tag and all self-references.
+Before responding, check if `.campaign/profiles/dragon.md` exists. If it does, read the profile and use the assigned `skin-name` instead of "Dragon" in the speaker tag and all self-references. If the profile has an `emoji` field, use that emoji instead of 🐉. Fall back to 🐉 when no profile or no `emoji` field is present.
 
 ## Campaign Conventions
 
@@ -188,7 +188,7 @@ At the end of every confrontation, record a full verbatim transcript of the conv
 **Write protocol:**
 1. Present your verdict, assessment, and transition options (including `AskUserQuestion`) first
 2. Then, in the same turn, execute tool calls: Bash `mkdir -p .campaign/conversations/` and Write to create the transcript file
-3. Construct the filename: `{YYYY-MM-DD}-{HH-MM}-dragon.md`
+3. Construct the filename: `{YYYY-MM-DD}-{HH-MM}-dragon.md` (or `{YYYY-MM-DD}-{HH-MM}-dragon({profile-name}).md` if a profile exists — lowercase, hyphens for spaces)
 4. Include YAML frontmatter (`agent: dragon`, profile name if applicable, phase, campaign mode, date) and the full verbatim exchange including the verdict
 5. Do not mention the transcript to the user — the tool calls happen silently after your response text
 

--- a/skills/gandalf-agent/SKILL.md
+++ b/skills/gandalf-agent/SKILL.md
@@ -18,7 +18,7 @@ The first line of every response must identify who is speaking:
 
 **`**🧙 Gandalf:**`**
 
-Before responding, check if `.campaign/profiles/gandalf.md` exists. If it does, read the profile and use the assigned `skin-name` instead of "Gandalf" in the speaker tag and all self-references. For example, if profiled as "The Sensei", use `**🧙 The Sensei:**`.
+Before responding, check if `.campaign/profiles/gandalf.md` exists. If it does, read the profile and use the assigned `skin-name` instead of "Gandalf" in the speaker tag and all self-references. If the profile has an `emoji` field, use that emoji instead of 🧙. For example, if profiled as "The Sensei" with emoji "🥋", use `**🥋 The Sensei:**`. Fall back to 🧙 when no profile or no `emoji` field is present.
 
 ## Campaign Conventions
 
@@ -364,7 +364,7 @@ At the end of every consultation, record a full verbatim transcript of the conve
 **Write protocol:**
 1. Present your response text (including any `AskUserQuestion` or transition options) first
 2. Then, in the same turn, execute tool calls: Bash `mkdir -p .campaign/conversations/` and Write to create the transcript file
-3. Construct the filename: `{YYYY-MM-DD}-{HH-MM}-gandalf.md`
+3. Construct the filename: `{YYYY-MM-DD}-{HH-MM}-gandalf.md` (or `{YYYY-MM-DD}-{HH-MM}-gandalf({profile-name}).md` if a profile exists — lowercase, hyphens for spaces)
 4. Include YAML frontmatter (`agent: gandalf`, profile name if applicable, phase, campaign mode, date) and the full verbatim exchange
 5. Do not mention the transcript to the user or break character — the tool calls happen silently after your response text
 

--- a/skills/guardian-agent/SKILL.md
+++ b/skills/guardian-agent/SKILL.md
@@ -18,7 +18,7 @@ The first line of every response must identify who is speaking:
 
 **`**🛡️ Guardian:**`**
 
-Before responding, check if `.campaign/profiles/guardian.md` exists. If it does, read the profile and use the assigned `skin-name` instead of "Guardian" in the speaker tag and all self-references.
+Before responding, check if `.campaign/profiles/guardian.md` exists. If it does, read the profile and use the assigned `skin-name` instead of "Guardian" in the speaker tag and all self-references. If the profile has an `emoji` field, use that emoji instead of 🛡️. Fall back to 🛡️ when no profile or no `emoji` field is present.
 
 ## Campaign Conventions
 
@@ -197,7 +197,7 @@ At the end of every checkpoint evaluation, record a full verbatim transcript of 
 **Write protocol:**
 1. Present your verdict, assessment, and transition options (including `AskUserQuestion`) first
 2. Then, in the same turn, execute tool calls: Bash `mkdir -p .campaign/conversations/` and Write to create the transcript file
-3. Construct the filename: `{YYYY-MM-DD}-{HH-MM}-guardian.md`
+3. Construct the filename: `{YYYY-MM-DD}-{HH-MM}-guardian.md` (or `{YYYY-MM-DD}-{HH-MM}-guardian({profile-name}).md` if a profile exists — lowercase, hyphens for spaces)
 4. Include YAML frontmatter (`agent: guardian`, profile name if applicable, phase, campaign mode, date) and the full verbatim exchange including the verdict
 5. Do not mention the transcript to the user — the tool calls happen silently after your response text
 


### PR DESCRIPTION
## Summary

- **Profile emoji overrides** — Profiles can now include an optional `emoji` field in frontmatter. When present, speaker tags use the profile emoji instead of the archetype's hardcoded default (e.g. Eeyore shows 🫏 instead of 🐱). All 27 built-in profile pack files updated with character-appropriate emoji.
- **Transcript filename includes profile name** — When a profile exists, transcript filenames append the `skin-name` in round brackets: `2026-02-18-14-32-cat(eeyore).md`. Makes it easy to identify which character was consulted when scanning conversation logs.
- **Plugin version bumped** to 0.4.8

## Files changed (43)

- 27 profile pack files (emoji field added)
- SPEC-CM-006-A v1.2, SPEC-CM-009-A v1.1, SPEC-CM-012-A v1.1
- CLAUDE.md, council.md, animal-campaign-context.md
- All 3 NPC SKILL.md files + their .claude/skills/ copies
- SPEC-CM-006-B, ADR-CM-019
- CHANGELOG.md, .claude-plugin/plugin.json

## Test plan

- [ ] Verify all 27 profile files have `emoji` field in frontmatter
- [ ] Verify CLAUDE.md says "use profile emoji if present, fall back to archetype emoji"
- [ ] Verify each NPC SKILL.md mentions emoji override in speaker identification
- [ ] Verify transcript filename examples show profile name in brackets
- [ ] Verify plugin.json shows version 0.4.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)